### PR TITLE
Add tables to enable groups feature

### DIFF
--- a/database/sql/tables/group_goals.sql
+++ b/database/sql/tables/group_goals.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS group_goals (
+    id BIGSERIAL PRIMARY KEY,
+    group_id BIGINT,
+    name VARCHAR,
+    target_value NUMERIC,
+    start_date TIMESTAMPZ,
+    end_date TIMESTAMPZ,
+    created_at TIMESTAMPZ,
+    CONSTRAINT fk_group_goals_group FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE
+);

--- a/database/sql/tables/group_members.sql
+++ b/database/sql/tables/group_members.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS group_members (
+    id BIGSERIAL PRIMARY KEY,
+    group_id BIGINT,
+    user_id BIGINT,
+    role VARCHAR,
+    joined_at TIMESTAMPZ,
+    CONSTRAINT fk_group_members_group FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE,
+    CONSTRAINT fk_group_members_users FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);

--- a/database/sql/tables/groups.sql
+++ b/database/sql/tables/groups.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS groups (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR,
+    created_by BIGINT,
+    created_at TIMESTAMPZ,
+    CONSTRAINT fk_groups_user FOREIGN KEY (created_by) REFERENCES users (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
Does this make sense for the tables required to add the groups feature? (as a starting point) 🐠  

Tables:
`groups`
`group_members`
`group_goals`
